### PR TITLE
Fix 'curl' error in docker base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,15 @@ MAINTAINER Alfonso Pérez (alpegon3@upv.es)
 RUN echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
 # Update and install all the necessary packages
+RUN apk del git --purge
+
+# Update and install all the necessary packages
 RUN apk add --no-cache \
     sudo \
     curl \
     wget \
     bash \
+    git \
     shadow@community
 
 # Add jenkins user/group


### PR DESCRIPTION
Fix curl errors:
  Error relocating /usr/bin/curl: curl_mime_data_cb: symbol not found
  Error relocating /usr/bin/curl: curl_mime_name: symbol not found
  Error relocating /usr/bin/curl: curl_mime_encoder: symbol not found
  Error relocating /usr/bin/curl: curl_mime_init: symbol not found
  Error relocating /usr/bin/curl: curl_mime_headers: symbol not found
  Error relocating /usr/bin/curl: curl_mime_filedata: symbol not found
  Error relocating /usr/bin/curl: curl_mime_free: symbol not found
  Error relocating /usr/bin/curl: curl_mime_subparts: symbol not found
  Error relocating /usr/bin/curl: curl_mime_type: symbol not found
  Error relocating /usr/bin/curl: curl_mime_addpart: symbol not found
  Error relocating /usr/bin/curl: curl_mime_filename: symbol not found
  Error relocating /usr/bin/curl: curl_mime_data: symbol not found